### PR TITLE
seems pycov-test needs pytest>=3.6 now

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 
 # required for tests:
 coverage
-pytest
+pytest>=3.6
 pytest-cov
 pep8
 


### PR DESCRIPTION
the default version of pytest in Travis env is 3.3 which is not enough for pytest-cov now. This caused the build to fail.